### PR TITLE
Reverted i18n gem to version 0.8.1

### DIFF
--- a/spec/test_app_templates/Gemfile.extra
+++ b/spec/test_app_templates/Gemfile.extra
@@ -7,4 +7,5 @@ end
 group :development do
   gem 'better_errors'
   gem 'binding_of_caller'
+  gem 'i18n', '0.8.1'
 end


### PR DESCRIPTION
Fixes test failures due to missing translations.

It appears that the curation_concerns gem is not compatible with i18n gem >= 0.8.3, so an explicit dependency for i18n version 0.8.1 is being added.

@samvera/sufia-code-reviewers
