### PR TITLE
Updating jquery-ui-rails to version 6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ group :development, :test do
 end
 
 # BEGIN ENGINE_CART BLOCK
-# engine_cart: 0.10.0
+# engine_cart: 2.2.0
 # engine_cart stanza: 0.10.0
 # the below comes from engine_cart, a gem used to test this Rails engine gem in the context of a Rails app.
 file = File.expand_path('Gemfile', ENV['ENGINE_CART_DESTINATION'] || ENV['RAILS_ROOT'] || File.expand_path('.internal_test_app', File.dirname(__FILE__)))

--- a/curation_concerns.gemspec
+++ b/curation_concerns.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'active-fedora', '>= 10.3.0.rc1'
   spec.add_dependency 'blacklight', '~> 6.3'
   spec.add_dependency 'breadcrumbs_on_rails', '>= 3.0.1', '< 4'
-  spec.add_dependency 'jquery-ui-rails', '~> 5.0.5'
+  spec.add_dependency 'jquery-ui-rails', '~> 6.0'
   spec.add_dependency 'simple_form', '~> 3.1'
   spec.add_dependency 'hydra-editor', '>= 2', '< 4'
   spec.add_dependency 'rails_autolink'
@@ -49,9 +49,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'solr_wrapper', '~> 0.16'
   spec.add_development_dependency 'fcrepo_wrapper', '~> 0.1'
   spec.add_development_dependency 'devise', '>= 3.0', '< 5'
-  spec.add_development_dependency "bundler", "~> 1.6"
+  spec.add_development_dependency "bundler", ">= 1.17.0"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "engine_cart", "~> 1.0"
+  spec.add_development_dependency "engine_cart", "~> 2.0"
   spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "rspec-its"
   spec.add_development_dependency "rspec-rails", '~> 3.5'

--- a/db/migrate/20160328222152_create_version_committers.rb
+++ b/db/migrate/20160328222152_create_version_committers.rb
@@ -1,4 +1,4 @@
-class CreateVersionCommitters < ActiveRecord::Migration
+class CreateVersionCommitters < ActiveRecord::Migration[4.2]
   def self.up
     create_table :version_committers do |t|
       t.string :obj_id

--- a/db/migrate/20160328222153_create_checksum_audit_logs.rb
+++ b/db/migrate/20160328222153_create_checksum_audit_logs.rb
@@ -1,4 +1,4 @@
-class CreateChecksumAuditLogs < ActiveRecord::Migration
+class CreateChecksumAuditLogs < ActiveRecord::Migration[4.2]
   def self.up
     create_table :checksum_audit_logs do |t|
       t.string :file_set_id

--- a/db/migrate/20160328222154_create_single_use_links.rb
+++ b/db/migrate/20160328222154_create_single_use_links.rb
@@ -1,4 +1,4 @@
-class CreateSingleUseLinks < ActiveRecord::Migration
+class CreateSingleUseLinks < ActiveRecord::Migration[4.2]
   def change
     create_table :single_use_links do |t|
       t.string :downloadKey

--- a/db/migrate/20160427155928_create_operations.rb
+++ b/db/migrate/20160427155928_create_operations.rb
@@ -1,4 +1,4 @@
-class CreateOperations < ActiveRecord::Migration
+class CreateOperations < ActiveRecord::Migration[4.2]
   def change
     create_table :curation_concerns_operations do |t|
       t.string :status

--- a/db/migrate/20160919151348_create_sipity.rb
+++ b/db/migrate/20160919151348_create_sipity.rb
@@ -1,4 +1,4 @@
-class CreateSipity < ActiveRecord::Migration
+class CreateSipity < ActiveRecord::Migration[4.2]
   def change
     create_table "sipity_notification_recipients" do |t|
       t.integer  "notification_id",                null: false

--- a/db/migrate/20161012182404_create_sipity_workflow_methods.rb
+++ b/db/migrate/20161012182404_create_sipity_workflow_methods.rb
@@ -1,4 +1,4 @@
-class CreateSipityWorkflowMethods < ActiveRecord::Migration
+class CreateSipityWorkflowMethods < ActiveRecord::Migration[4.2]
   def change
     create_table :sipity_workflow_methods do |t|
       t.string   "service_name",                    null: false

--- a/db/migrate/20170308175556_add_allows_access_grant_to_workflow.rb
+++ b/db/migrate/20170308175556_add_allows_access_grant_to_workflow.rb
@@ -1,4 +1,4 @@
-class AddAllowsAccessGrantToWorkflow < ActiveRecord::Migration
+class AddAllowsAccessGrantToWorkflow < ActiveRecord::Migration[4.2]
   def change
     add_column :sipity_workflows, :allows_access_grant, :boolean
   end


### PR DESCRIPTION
Updates the JQuery UI Rails gem to the latest 6.x version. This addresses several security concerns in JQuery.

See https://github.com/psu-stewardship/scholarsphere/issues/1462

@projecthydra/sufia-code-reviewers
